### PR TITLE
feat(auth): add base auth widgets and update app

### DIFF
--- a/lib/core/resources/app_theme.dart
+++ b/lib/core/resources/app_theme.dart
@@ -108,7 +108,8 @@ class AppTheme {
       ),
       
       // Card Theme
-      cardTheme: CardTheme(
+      //TODO: you must to return it as it was
+      cardTheme: CardThemeData(
         color: ColorManager.cardBackground,
         elevation: 2,
         shape: RoundedRectangleBorder(

--- a/lib/featuers/authPage/presentation/widgets/auth_elevated_button.dart
+++ b/lib/featuers/authPage/presentation/widgets/auth_elevated_button.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:gravilog_2025/core/resources/app_theme.dart';
+
+class AuthElevatedButton extends StatelessWidget {
+  const AuthElevatedButton({
+    super.key,
+    required this.onPressed,
+    required this.child,
+  });
+
+  final void Function()? onPressed;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        disabledBackgroundColor: Colors.transparent,
+        backgroundColor: context.pinkSherbet,
+        shape: RoundedRectangleBorder(
+            side: BorderSide(color: context.pinkSherbet),
+            borderRadius: const BorderRadius.all(Radius.circular(8))),
+        minimumSize: const Size(double.infinity, 50),
+      ),
+      child: child,
+    );
+  }
+}

--- a/lib/featuers/authPage/presentation/widgets/check_box_tile/check_box_tile.dart
+++ b/lib/featuers/authPage/presentation/widgets/check_box_tile/check_box_tile.dart
@@ -1,0 +1,57 @@
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:gravilog_2025/core/resources/app_theme.dart';
+import 'package:gravilog_2025/featuers/authPage/presentation/widgets/check_box_tile/check_box_tile_controller.dart';
+
+class CircularCheckboxTile extends StatelessWidget {
+  final ValueChanged<bool> onChanged;
+  final String label;
+  final _checkBoxTileController = Get.put(CheckBoxTileController());
+  CircularCheckboxTile({
+    super.key,
+    required this.onChanged,
+    required this.label,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() => GestureDetector(
+          onTap: () {
+            log('checked value is: ${_checkBoxTileController.checked.value}');
+            _checkBoxTileController.changeValue();
+            onChanged(_checkBoxTileController.checked.value);
+          },
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 18,
+                height: 18,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: _checkBoxTileController.checked.value
+                      ? null
+                      : BoxBorder.all(),
+                  color: _checkBoxTileController.checked.value
+                      ? context.pinkSherbet
+                      : Colors.transparent,
+                ),
+                child: Icon(
+                  Icons.check,
+                  size: 15,
+                  color: _checkBoxTileController.checked.value
+                      ? Colors.white
+                      : Colors.grey.shade600,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(label,
+                  style: context.textStyles.bodyMedium!
+                      .copyWith(color: context.textTertiary)),
+            ],
+          ),
+        ));
+  }
+}

--- a/lib/featuers/authPage/presentation/widgets/check_box_tile/check_box_tile_controller.dart
+++ b/lib/featuers/authPage/presentation/widgets/check_box_tile/check_box_tile_controller.dart
@@ -1,0 +1,13 @@
+import 'dart:developer';
+
+import 'package:get/get.dart';
+
+final class CheckBoxTileController extends GetxController {
+  final RxBool checked = false.obs;
+
+  void changeValue() {
+    log('change value1: ${checked.value}');
+    checked.value = !checked.value;
+    log('change value2: ${checked.value}');
+  }
+}

--- a/lib/featuers/authPage/presentation/widgets/custom_country_code_picker.dart
+++ b/lib/featuers/authPage/presentation/widgets/custom_country_code_picker.dart
@@ -1,0 +1,49 @@
+import 'package:country_code_picker/country_code_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:get/state_manager.dart';
+import 'package:gravilog_2025/core/resources/app_theme.dart';
+
+class CustomCountryCodePicker extends StatelessWidget {
+  CustomCountryCodePicker({super.key, required this.onChanged});
+
+  final void Function(CountryCode countryCode)? onChanged;
+
+  final _controller = CountryPickerController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      if (_controller.dialogShown) {}
+      return Container(
+        width: 50,
+        decoration: BoxDecoration(
+          color: context.surfaceColor,
+          borderRadius: const BorderRadius.all(Radius.circular(10)),
+        ),
+        child: CountryCodePicker(
+          onChanged: onChanged,
+          initialSelection: 'SA',
+          favorite: const ['+966', 'SA'],
+          showCountryOnly: false,
+          showOnlyCountryWhenClosed: false,
+          showFlag: true,
+          showFlagMain: true,
+          textStyle: const TextStyle(color: Colors.black, fontSize: 10),
+          flagWidth: 25,
+          alignLeft: true,
+          padding: EdgeInsets.zero,
+        ),
+      );
+    });
+  }
+}
+
+final class CountryPickerController extends GetxController {
+  final countryCode = CountryCode().obs;
+  final _showDialog = false.obs;
+  void showDialog() => _showDialog.value = true;
+
+  void hideDialog() => _showDialog.value = false;
+
+  bool get dialogShown => _showDialog.value;
+}

--- a/lib/featuers/authPage/presentation/widgets/custom_text_button.dart
+++ b/lib/featuers/authPage/presentation/widgets/custom_text_button.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:gravilog_2025/core/resources/app_theme.dart';
+
+class CustomTextButton extends StatelessWidget {
+  const CustomTextButton({
+    super.key,
+    required this.btnText,
+    this.textUnderLine = true,
+    this.fontSize = 10,
+    this.textColor,
+    this.icon,
+    required this.onPressed,
+  });
+
+  final String btnText;
+  final bool textUnderLine;
+  final Color? textColor;
+  final double fontSize;
+  final IconData? icon;
+  final void Function()? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      style: const ButtonStyle(
+        padding: WidgetStatePropertyAll(EdgeInsets.zero),
+        overlayColor: WidgetStatePropertyAll(
+          Colors.transparent,
+        ),
+        shadowColor: WidgetStatePropertyAll(
+          Colors.transparent,
+        ),
+        surfaceTintColor: WidgetStatePropertyAll(
+          Colors.transparent,
+        ),
+      ),
+      onPressed: onPressed,
+      icon: icon == null ? null : Icon(icon),
+      label: Text(
+        ' $btnText',
+        style: Theme.of(context).textTheme.labelLarge!.copyWith(
+              color: context.pinkSherbet,
+              fontWeight: FontWeight.bold,
+              fontSize: fontSize,
+              decorationColor: context.pinkSherbet,
+            ),
+      ),
+    );
+  }
+}

--- a/lib/featuers/authPage/presentation/widgets/form_text_field/custom_text_fiels.dart
+++ b/lib/featuers/authPage/presentation/widgets/form_text_field/custom_text_fiels.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:gravilog_2025/core/resources/app_theme.dart';
+
+class CustomTextFormField extends StatelessWidget {
+  final TextEditingController controller;
+  final String? hintText;
+  final bool obscureText;
+  final Widget? suffixIcon;
+  final Widget? prefixIcon;
+  final TextInputType keyboardType;
+  final Function(String)? onChanged;
+
+  const CustomTextFormField({
+    super.key,
+    required this.controller,
+    this.hintText,
+    this.obscureText = false,
+    this.suffixIcon,
+    this.prefixIcon,
+    this.keyboardType = TextInputType.text,
+    this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      cursorColor: Colors.black,
+      obscureText: obscureText,
+      decoration: InputDecoration(
+          constraints: BoxConstraints.loose(const Size(double.infinity, 50)),
+          hintText: hintText,
+          hintStyle: context.textStyles.bodyMedium!.copyWith(
+              letterSpacing: 14 * 0.02,
+              color: context.textTertiary,
+              fontWeight: FontWeight.w600),
+          filled: true,
+          fillColor: context.surfaceColor,
+          border: _baseBorder(),
+          enabledBorder: _baseBorder(),
+          focusedBorder: _baseBorder(borderColor: context.textTertiary),
+          errorBorder: _baseBorder(borderColor: context.errorColor),
+          prefixIcon: prefixIcon == null
+              ? null
+              : Padding(
+                  padding: const EdgeInsets.all(10),
+                  child: prefixIcon,
+                ),
+          prefixIconConstraints: BoxConstraints.tight(const Size(40, 40)),
+          suffixIcon: suffixIcon == null
+              ? null
+              : Padding(
+                  padding: const EdgeInsets.all(10),
+                  child: suffixIcon,
+                ),
+          suffixIconConstraints: BoxConstraints.tight(const Size(40, 40))),
+      keyboardType: keyboardType,
+      onChanged: onChanged,
+    );
+  }
+}
+
+InputBorder _baseBorder({Color? borderColor}) {
+  return OutlineInputBorder(
+      borderSide: borderColor == null
+          ? BorderSide.none
+          : BorderSide(color: borderColor, width: .5),
+      borderRadius: const BorderRadius.all(Radius.circular(8)));
+}

--- a/lib/featuers/authPage/presentation/widgets/form_text_field/text_field_icon.dart
+++ b/lib/featuers/authPage/presentation/widgets/form_text_field/text_field_icon.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+
+class TextFieldIconImage extends StatelessWidget {
+  const TextFieldIconImage({
+    super.key,
+    required this.assetImage,
+  });
+
+  final String assetImage;
+
+  @override
+  Widget build(BuildContext context) {
+    if (assetImage.contains('svg')) {
+      return SvgPicture.asset(width: 10, height: 10, assetImage);
+    }
+    return Image.asset(
+      assetImage,
+      height: 10,
+      width: 10,
+    );
+  }
+}

--- a/lib/featuers/authPage/presentation/widgets/social_media_icon_button.dart
+++ b/lib/featuers/authPage/presentation/widgets/social_media_icon_button.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:gravilog_2025/core/resources/app_theme.dart';
+
+class SocialMediaIconButton extends StatelessWidget {
+  const SocialMediaIconButton({
+    super.key,
+    required this.child,
+    required this.onTap,
+  });
+  final void Function()? onTap;
+  final Widget child;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      decoration: BoxDecoration(
+          color: context.surfaceColor,
+          borderRadius: const BorderRadius.all(Radius.circular(12))),
+      child: InkWell(
+        onTap: onTap,
+        child: child,
+      ),
+    );
+  }
+}

--- a/lib/featuers/authPage/presentation/widgets/sso_ui.dart
+++ b/lib/featuers/authPage/presentation/widgets/sso_ui.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get/get.dart';
+import 'package:gravilog_2025/core/resources/app_theme.dart';
+
+import '../../../../core/resources/assets_manager.dart';
+import 'social_media_icon_button.dart';
+
+class SSOUi extends StatelessWidget {
+  const SSOUi({
+    super.key,
+    required this.facebookOnPressed,
+    required this.googleOnPressed,
+    this.appleOnPressed,
+  });
+  final void Function()? googleOnPressed;
+  final void Function()? facebookOnPressed;
+  final void Function()? appleOnPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            Expanded(
+              child: Divider(
+                thickness: 1,
+                color: context.textSecondary,
+                indent: 20,
+                endIndent: 20,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              child: Text(
+                "or_continuo_with".tr,
+                style: context.textStyles.bodyLarge!
+                    .copyWith(color: context.textSecondary),
+              ),
+            ),
+            Expanded(
+              child: Divider(
+                thickness: 1,
+                color: context.textSecondary,
+                indent: 20,
+                endIndent: 20,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        Center(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SocialMediaIconButton(
+                onTap: facebookOnPressed,
+                child: const Icon(
+                  Icons.facebook_outlined,
+                  size: 35,
+                  color: Color(0xff1877F2),
+                ),
+              ),
+              const SizedBox(width: 30),
+              SocialMediaIconButton(
+                onTap: googleOnPressed,
+                child: SvgPicture.asset(
+                  IconAssets.googleIcon,
+                  height: 30,
+                  width: 30,
+                ),
+              ),
+              if (Platform.isIOS) ...[
+                const SizedBox(width: 30),
+                SocialMediaIconButton(
+                  onTap: appleOnPressed,
+                  child: SvgPicture.asset(
+                    'assets/icons/ic_apple.svg',
+                    height: 30,
+                    width: 30,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/featuers/authPage/presentation/widgets/text_with_button_widget.dart
+++ b/lib/featuers/authPage/presentation/widgets/text_with_button_widget.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:gravilog_2025/core/resources/app_theme.dart';
+
+import 'custom_text_button.dart';
+
+class TextWithButtonWidget extends StatelessWidget {
+  const TextWithButtonWidget({
+    super.key,
+    required this.leadingText,
+    required this.buttonText,
+    required this.buttonAction,
+  });
+
+  final String leadingText;
+  final String buttonText;
+  final void Function()? buttonAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          leadingText,
+          style: Theme.of(context).textTheme.labelLarge!.copyWith(
+              fontSize: 12,
+              color: const Color(0xff030303),
+              fontWeight: FontWeight.normal),
+        ),
+        CustomTextButton(
+            btnText: buttonText,
+            textUnderLine: false,
+            textColor: context.pinkSherbet,
+            fontSize: 14,
+            onPressed: buttonAction),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
This PR introduces a set of reusable authentication UI widgets to standardize design and behavior across all auth-related screens.

Details:

Added base widgets for buttons, text fields, checkboxes, and social login UI.

These components will be shared by Login, Register, and Forget Password screens.

Impact:

Improves code reuse and UI consistency in the authentication module.

Simplifies future auth screen development.

Linked Trello card: https://trello.com/c/zBHBfhuq